### PR TITLE
Feature/custom token validation

### DIFF
--- a/packages/server/src/AccountsServer.js
+++ b/packages/server/src/AccountsServer.js
@@ -46,13 +46,14 @@ export class AccountsServer {
 
     if (this.options.passwordAuthenticator) {
       try {
-        foundUser = await this._externalPasswordAuthenticator(this.options.passwordAuthenticator, user, password);
-      }
-      catch (e) {
+        foundUser = await this._externalPasswordAuthenticator(
+          this.options.passwordAuthenticator,
+          user,
+          password);
+      } catch (e) {
         throw new AccountsError(e, user, 403);
       }
-    }
-    else {
+    } else {
       foundUser = await this._defaultPasswordAuthenticator(user, password);
     }
 
@@ -74,11 +75,12 @@ export class AccountsServer {
     };
   }
 
-  async _externalPasswordAuthenticator(authFn, user: PasswordLoginUserType, password: string) {
-    return await authFn(user, password);
+  // eslint-disable-next-line max-len
+  async _externalPasswordAuthenticator(authFn: Function, user: PasswordLoginUserType, password: string): Promise<any> {
+    return authFn(user, password);
   }
 
-  async _defaultPasswordAuthenticator(user: PasswordLoginUserType, password: string) {
+  async _defaultPasswordAuthenticator(user: PasswordLoginUserType, password: string): Promise<any> {
     const { username, email, id } = isString(user)
       ? toUsernameAndEmail({ user })
       : toUsernameAndEmail({ ...user });
@@ -213,8 +215,7 @@ export class AccountsServer {
       if (this.options.resumeSessionValidator) {
         try {
           await this.options.resumeSessionValidator(user, session);
-        }
-        catch (e) {
+        } catch (e) {
           throw new AccountsError(e, { id: session.userId }, 403);
         }
       }

--- a/packages/server/src/AccountsServer.js
+++ b/packages/server/src/AccountsServer.js
@@ -209,6 +209,16 @@ export class AccountsServer {
       if (!user) {
         throw new AccountsError('User not found', { id: session.userId });
       }
+
+      if (this.options.resumeSessionValidator) {
+        try {
+          await this.options.resumeSessionValidator(user, session);
+        }
+        catch (e) {
+          throw new AccountsError(e, { id: session.userId }, 403);
+        }
+      }
+
       return user;
     }
     return null;

--- a/packages/server/src/AccountsServer.spec.js
+++ b/packages/server/src/AccountsServer.spec.js
@@ -40,7 +40,7 @@ describe('Accounts', () => {
     findUserByUsername: () => Promise.resolve(),
     findUserByEmail: () => Promise.resolve(),
     createUser: () => Promise.resolve(),
-    createSession: () => Promise.resolve()
+    createSession: () => Promise.resolve(),
   };
   describe('createUser', () => {
     beforeEach(() => {
@@ -196,7 +196,7 @@ describe('Accounts', () => {
       };
       const authenticator = jest.fn(() => Promise.resolve(user));
 
-      Accounts.config({ passwordAuthenticator: authenticator}, db);
+      Accounts.config({ passwordAuthenticator: authenticator }, db);
 
       const result = await Accounts.loginWithPassword('username', '123456');
 
@@ -403,7 +403,7 @@ describe('Accounts', () => {
         userId: '123',
         username: 'username',
       };
-      Accounts.config({ resumeSessionValidator: resumeSessionValidator}, {
+      Accounts.config({ resumeSessionValidator }, {
         findSessionById: () => Promise.resolve({
           sessionId: '456',
           valid: true,
@@ -424,7 +424,7 @@ describe('Accounts', () => {
         userId: '123',
         username: 'username',
       };
-      Accounts.config({ resumeSessionValidator: resumeSessionValidator}, {
+      Accounts.config({ resumeSessionValidator }, {
         findSessionById: () => Promise.resolve({
           sessionId: '456',
           valid: true,
@@ -438,8 +438,7 @@ describe('Accounts', () => {
       try {
         await Accounts.resumeSession(accessToken);
         throw new Error();
-      }
-      catch (err) {
+      } catch (err) {
         expect(resumeSessionValidator.mock.calls.length).toBe(1);
         expect(err.message).toEqual('Custom session error');
       }

--- a/packages/server/src/AccountsServer.spec.js
+++ b/packages/server/src/AccountsServer.spec.js
@@ -396,6 +396,54 @@ describe('Accounts', () => {
         expect(foundUser).toEqual(user);
       });
     });
+    it('return user with custom validation method', async () => {
+      const resumeSessionValidator = jest.fn(() => Promise.resolve({}));
+
+      const user = {
+        userId: '123',
+        username: 'username',
+      };
+      Accounts.config({ resumeSessionValidator: resumeSessionValidator}, {
+        findSessionById: () => Promise.resolve({
+          sessionId: '456',
+          valid: true,
+          userId: '123',
+        }),
+        findUserById: () => Promise.resolve(user),
+      });
+
+      const { accessToken } = Accounts.instance.createTokens('456');
+      await Accounts.resumeSession(accessToken);
+
+      expect(resumeSessionValidator.mock.calls.length).toBe(1);
+    });
+    it('throw when custom validation method rejects', async () => {
+      const resumeSessionValidator = jest.fn(() => Promise.reject('Custom session error'));
+
+      const user = {
+        userId: '123',
+        username: 'username',
+      };
+      Accounts.config({ resumeSessionValidator: resumeSessionValidator}, {
+        findSessionById: () => Promise.resolve({
+          sessionId: '456',
+          valid: true,
+          userId: '123',
+        }),
+        findUserById: () => Promise.resolve(user),
+      });
+
+      const { accessToken } = Accounts.instance.createTokens('456');
+
+      try {
+        await Accounts.resumeSession(accessToken);
+        throw new Error();
+      }
+      catch (err) {
+        expect(resumeSessionValidator.mock.calls.length).toBe(1);
+        expect(err.message).toEqual('Custom session error');
+      }
+    });
     describe('setProfile', () => {
       it('calls set profile on db interface', async () => {
         const user = {


### PR DESCRIPTION
Added feature that allows developer to set custom `resumeSessionValidator` using the `Accounts.config`.
The method is called as async method, and should resolve without throw - otherwise the error is used as AccountsError. 
If the Promise returned from the method is valid - the `resumeSession` will return correctly with the user. 

Also, added unit tests and fixed all lint errors.