### PR TITLE
sendVerificationEmail and setup email

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ AccountsServer.config({
  siteUrl: 'https://my-app.com',
  email: // a valid email config object passed to emailjs
  // https://github.com/eleith/emailjs#example-usage---text-only-emails
+ // You can handle the send of the emails by providing an optional sendMail function
+ // sendMail: ({ from, to, text, html }): Promise<void>
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,3 +39,21 @@ npm i -S @accounts/sql
 ## Example
 
 You can find a working example [here](https://github.com/js-accounts/rest-example).
+
+## Emails
+
+Configuration:
+```javascript
+AccountsServer.config({
+ siteUrl: 'https://my-app.com',
+ email: // a valid email config object passed to emailjs
+ // https://github.com/eleith/emailjs#example-usage---text-only-emails
+});
+```
+
+To overwrite the email templates:
+```javascript
+AccountsServer.emailTemplates.from = 'my-app <no-reply@my-app.com>';
+AccountsServer.emailTemplates.verifyEmail.subject = (user) => `Verify your account email ${user.profile.lastname}`;
+AccountsServer.emailTemplates.verifyEmail.text = (user, url) => `To verify your account email please click on this link: ${url}`;
+```

--- a/packages/common/src/config.js
+++ b/packages/common/src/config.js
@@ -2,6 +2,7 @@ import { EMAIL_ONLY } from './passwordSignupFields';
 // eslint-disable-next-line import/no-named-as-default
 
 export default {
+  siteUrl: 'http://localhost:3000',
   sendVerificationEmail: false,
   sendEnrollmentEmail: false,
   sendWelcomeEmail: false,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -43,6 +43,7 @@
     "@accounts/common": "^0.0.4",
     "bcryptjs": "^2.4.0",
     "crypto": "^0.0.3",
+    "emailjs": "^1.0.8",
     "jsonwebtoken": "^7.2.1",
     "jwt-decode": "^2.1.0",
     "lodash": "^4.16.4"

--- a/packages/server/src/AccountsServer.js
+++ b/packages/server/src/AccountsServer.js
@@ -21,6 +21,7 @@ import { verifyPassword } from './encryption';
 import {
   generateAccessToken,
   generateRefreshToken,
+  generateEmailToken,
 } from './tokens';
 import Email from './email';
 import emailTemplates from './emailTemplates';
@@ -335,14 +336,15 @@ export class AccountsServer {
     if (!address || !includes(user.emails.map((email: string) => email.address), address)) {
       throw new AccountsError('No such email address for user');
     }
-    const token = await this.db.addEmailVerificationToken(userId, address);
-    const resetPasswordUrl = `${this._options.siteUrl}/verify-email/${token}`;
+    const token = generateEmailToken();
+    await this.db.addEmailVerificationToken(userId, address, token);
+    const verifyEmailUrl = `${this._options.siteUrl}/verify-email/${token}`;
     await this.email.sendMail({
       from: this.emailTemplates.verifyEmail.from ?
         this.emailTemplates.verifyEmail.from : this.emailTemplates.from,
       to: address,
       subject: this.emailTemplates.verifyEmail.subject(user),
-      text: this.emailTemplates.verifyEmail.text(user, resetPasswordUrl),
+      text: this.emailTemplates.verifyEmail.text(user, verifyEmailUrl),
     });
   }
 }

--- a/packages/server/src/AccountsServer.js
+++ b/packages/server/src/AccountsServer.js
@@ -39,7 +39,11 @@ export class AccountsServer {
       throw new AccountsError('A database driver is required');
     }
     this.db = db;
-    this.email = new Email(config.email);
+    if (options.sendMail) {
+      this.email = { sendMail: options.sendMail };
+    } else {
+      this.email = new Email(config.email);
+    }
     this.emailTemplates = emailTemplates;
   }
 

--- a/packages/server/src/AccountsServer.js
+++ b/packages/server/src/AccountsServer.js
@@ -383,7 +383,7 @@ export class AccountsServer {
       throw new AccountsError('No such email address for user');
     }
     const token = generateRandomToken();
-    await this.db.addPasswordResetToken(userId, address, token);
+    await this.db.addResetPasswordToken(userId, address, token);
     const resetPasswordUrl = `${this._options.siteUrl}/reset-password/${token}`;
     await this.email.sendMail({
       from: this.emailTemplates.resetPassword.from ?

--- a/packages/server/src/AccountsServer.js
+++ b/packages/server/src/AccountsServer.js
@@ -284,7 +284,7 @@ export class AccountsServer {
   }
 
   async verifyEmail(token: string): Promise<void> {
-    const user = await this.db.findUserByEmailVerificationToken();
+    const user = await this.db.findUserByEmailVerificationToken(token);
     if (!user) {
       throw new AccountsError('Verify email link expired');
     }
@@ -336,7 +336,7 @@ export class AccountsServer {
       throw new AccountsError('No such email address for user');
     }
     const token = await this.db.addEmailVerificationToken(userId, address);
-    const resetPasswordUrl = `${this._options.siteUrl}/reset-password/${token}`;
+    const resetPasswordUrl = `${this._options.siteUrl}/verify-email/${token}`;
     await this.email.sendMail({
       from: this.emailTemplates.verifyEmail.from ?
         this.emailTemplates.verifyEmail.from : this.emailTemplates.from,

--- a/packages/server/src/AccountsServer.spec.js
+++ b/packages/server/src/AccountsServer.spec.js
@@ -720,7 +720,7 @@ describe('Accounts', () => {
         };
         Accounts.config({}, {
           findUserById: () => Promise.resolve(user),
-          addPasswordResetToken: () => Promise.resolve('token'),
+          addResetPasswordToken: () => Promise.resolve('token'),
         });
         Accounts.email = { sendMail: jest.fn() };
         await Accounts.sendResetPasswordEmail('userId');
@@ -737,7 +737,7 @@ describe('Accounts', () => {
         };
         Accounts.config({}, {
           findUserById: () => Promise.resolve(user),
-          addPasswordResetToken: () => Promise.resolve('token'),
+          addResetPasswordToken: () => Promise.resolve('token'),
         });
         Accounts.email = { sendMail: jest.fn() };
         await Accounts.sendResetPasswordEmail('userId', 'email');

--- a/packages/server/src/AccountsServer.spec.js
+++ b/packages/server/src/AccountsServer.spec.js
@@ -651,6 +651,23 @@ describe('Accounts', () => {
         }
       });
 
+      it('should send to first unverified email', async () => {
+        const user = {
+          emails: [{ address: 'email' }],
+        };
+        Accounts.config({}, {
+          findUserById: () => Promise.resolve(user),
+          addEmailVerificationToken: () => Promise.resolve('token'),
+        });
+        Accounts.email = { sendMail: jest.fn() };
+        await Accounts.sendVerificationEmail('userId');
+        expect(Accounts.email.sendMail.mock.calls.length).toEqual(1);
+        expect(Accounts.email.sendMail.mock.calls[0][0].from).toBeTruthy();
+        expect(Accounts.email.sendMail.mock.calls[0][0].to).toEqual('email');
+        expect(Accounts.email.sendMail.mock.calls[0][0].subject).toBeTruthy();
+        expect(Accounts.email.sendMail.mock.calls[0][0].text).toBeTruthy();
+      });
+
       it('should send email', async () => {
         const user = {
           emails: [{ address: 'email' }],
@@ -661,6 +678,69 @@ describe('Accounts', () => {
         });
         Accounts.email = { sendMail: jest.fn() };
         await Accounts.sendVerificationEmail('userId', 'email');
+        expect(Accounts.email.sendMail.mock.calls.length).toEqual(1);
+        expect(Accounts.email.sendMail.mock.calls[0][0].from).toBeTruthy();
+        expect(Accounts.email.sendMail.mock.calls[0][0].to).toEqual('email');
+        expect(Accounts.email.sendMail.mock.calls[0][0].subject).toBeTruthy();
+        expect(Accounts.email.sendMail.mock.calls[0][0].text).toBeTruthy();
+      });
+    });
+
+    describe('sendResetPasswordEmail', () => {
+      it('throws error if user is not found', async () => {
+        Accounts.config({}, {
+          findUserById: () => Promise.resolve(null),
+        });
+        try {
+          await Accounts.sendResetPasswordEmail();
+          throw new Error();
+        } catch (err) {
+          expect(err.message).toEqual('User not found');
+        }
+      });
+
+      it('throws when bad email address passed', async () => {
+        const user = {
+          emails: [{ address: 'email' }],
+        };
+        Accounts.config({}, {
+          findUserById: () => Promise.resolve(user),
+        });
+        try {
+          await Accounts.sendResetPasswordEmail('userId', 'toto');
+          throw new Error();
+        } catch (err) {
+          expect(err.message).toEqual('No such email address for user');
+        }
+      });
+
+      it('should send to first user email', async () => {
+        const user = {
+          emails: [{ address: 'email' }],
+        };
+        Accounts.config({}, {
+          findUserById: () => Promise.resolve(user),
+          addPasswordResetToken: () => Promise.resolve('token'),
+        });
+        Accounts.email = { sendMail: jest.fn() };
+        await Accounts.sendResetPasswordEmail('userId');
+        expect(Accounts.email.sendMail.mock.calls.length).toEqual(1);
+        expect(Accounts.email.sendMail.mock.calls[0][0].from).toBeTruthy();
+        expect(Accounts.email.sendMail.mock.calls[0][0].to).toEqual('email');
+        expect(Accounts.email.sendMail.mock.calls[0][0].subject).toBeTruthy();
+        expect(Accounts.email.sendMail.mock.calls[0][0].text).toBeTruthy();
+      });
+
+      it('should send email', async () => {
+        const user = {
+          emails: [{ address: 'email' }],
+        };
+        Accounts.config({}, {
+          findUserById: () => Promise.resolve(user),
+          addPasswordResetToken: () => Promise.resolve('token'),
+        });
+        Accounts.email = { sendMail: jest.fn() };
+        await Accounts.sendResetPasswordEmail('userId', 'email');
         expect(Accounts.email.sendMail.mock.calls.length).toEqual(1);
         expect(Accounts.email.sendMail.mock.calls[0][0].from).toBeTruthy();
         expect(Accounts.email.sendMail.mock.calls[0][0].to).toEqual('email');

--- a/packages/server/src/DBInterface.js
+++ b/packages/server/src/DBInterface.js
@@ -22,5 +22,6 @@ export interface DBInterface {
   updateSession(sessionId: string, ip: string, userAgent: string) : Promise<void>,
   invalidateSession(sessionId: string): Promise<void>,
   findSessionById(sessionId: string) : Promise<?SessionType>,
+  addEmailVerificationToken(userId: string, email: string) : Promise<string>,
   setProfile(userId: string, profile: Object) : Promise<Object>
 }

--- a/packages/server/src/DBInterface.js
+++ b/packages/server/src/DBInterface.js
@@ -22,6 +22,6 @@ export interface DBInterface {
   updateSession(sessionId: string, ip: string, userAgent: string) : Promise<void>,
   invalidateSession(sessionId: string): Promise<void>,
   findSessionById(sessionId: string) : Promise<?SessionType>,
-  addEmailVerificationToken(userId: string, email: string) : Promise<string>,
+  addEmailVerificationToken(userId: string, email: string, token: string) : Promise<string>,
   setProfile(userId: string, profile: Object) : Promise<Object>
 }

--- a/packages/server/src/DBInterface.js
+++ b/packages/server/src/DBInterface.js
@@ -13,6 +13,7 @@ export interface DBInterface {
   findUserByUsername(username: string) : Promise<?UserObjectType>,
   findUserById(userId: string) : Promise<?UserObjectType>,
   findUserByEmailVerificationToken(token: string) : Promise<?UserObjectType>,
+  findUserByResetPasswordToken(token: string) : Promise<?UserObjectType>,
   setUsername(userId: string, newUsername: string) : Promise<void>,
   addEmail(userId: string, newEmail: string, verified: boolean) : Promise<void>,
   removeEmail(userId: string, email: string) : Promise<void>,
@@ -21,8 +22,10 @@ export interface DBInterface {
   createSession(userId: string, ip: ?string, userAgent: ?string) : Promise<string>,
   updateSession(sessionId: string, ip: string, userAgent: string) : Promise<void>,
   invalidateSession(sessionId: string): Promise<void>,
+  invalidateAllSessions(userId: string): Promise<void>,
   findSessionById(sessionId: string) : Promise<?SessionType>,
   addEmailVerificationToken(userId: string, email: string, token: string) : Promise<void>,
   addPasswordResetToken(userId: string, email: string, token: string) : Promise<void>,
+  setResetPasssword(userId: string, email: string, newPassword: string, token: string) : Promise<void>,
   setProfile(userId: string, profile: Object) : Promise<Object>
 }

--- a/packages/server/src/DBInterface.js
+++ b/packages/server/src/DBInterface.js
@@ -25,7 +25,7 @@ export interface DBInterface {
   invalidateAllSessions(userId: string): Promise<void>,
   findSessionById(sessionId: string) : Promise<?SessionType>,
   addEmailVerificationToken(userId: string, email: string, token: string) : Promise<void>,
-  addPasswordResetToken(userId: string, email: string, token: string) : Promise<void>,
+  addResetPasswordToken(userId: string, email: string, token: string) : Promise<void>,
   setResetPasssword(userId: string, email: string, newPassword: string, token: string) : Promise<void>,
   setProfile(userId: string, profile: Object) : Promise<Object>
 }

--- a/packages/server/src/DBInterface.js
+++ b/packages/server/src/DBInterface.js
@@ -22,6 +22,7 @@ export interface DBInterface {
   updateSession(sessionId: string, ip: string, userAgent: string) : Promise<void>,
   invalidateSession(sessionId: string): Promise<void>,
   findSessionById(sessionId: string) : Promise<?SessionType>,
-  addEmailVerificationToken(userId: string, email: string, token: string) : Promise<string>,
+  addEmailVerificationToken(userId: string, email: string, token: string) : Promise<void>,
+  addPasswordResetToken(userId: string, email: string, token: string) : Promise<void>,
   setProfile(userId: string, profile: Object) : Promise<Object>
 }

--- a/packages/server/src/email.js
+++ b/packages/server/src/email.js
@@ -10,7 +10,7 @@ class Email {
 
   sendMail(mail: Object): Promise<Object> {
     return new Promise((resolve, reject) => { // eslint-disable-line flowtype/require-parameter-type
-      // If no configuration for email just warm the user
+      // If no configuration for email just warn the user
       if (!this.server) {
         console.log('No configuration for email, you must set an email configuration');
         resolve();

--- a/packages/server/src/email.js
+++ b/packages/server/src/email.js
@@ -1,0 +1,27 @@
+// @flow
+import email from 'emailjs';
+
+class Email {
+  constructor(emailConfig: Object) {
+    if (emailConfig) {
+      this.server = email.server.connect(emailConfig);
+    }
+  }
+
+  sendMail(mail: Object): Promise<Object> {
+    return new Promise((resolve, reject) => { // eslint-disable-line flowtype/require-parameter-type
+      // If no configuration for email just warm the user
+      if (!this.server) {
+        console.log('No configuration for email, you must set an email configuration');
+        resolve();
+        return;
+      }
+      this.server.send(mail, (err: Object, message: Object) => {
+        if (err) return reject(err);
+        return resolve(message);
+      });
+    });
+  }
+}
+
+export default Email;

--- a/packages/server/src/emailTemplates.js
+++ b/packages/server/src/emailTemplates.js
@@ -7,4 +7,9 @@ export default {
     subject: () => 'Verify your account email',
     text: (user: UserObjectType, url: string) => `To verify your account email please click on this link: ${url}`,
   },
+
+  resetPassword: {
+    subject: () => 'Reset your password',
+    text: (user: UserObjectType, url: string) => `To reset your password please click on this link: ${url}`,
+  },
 };

--- a/packages/server/src/emailTemplates.js
+++ b/packages/server/src/emailTemplates.js
@@ -1,0 +1,10 @@
+// @flow
+
+export default {
+  from: 'js-accounts <no-reply@js-accounts.com>',
+
+  verifyEmail: {
+    subject: () => 'Verify your account email',
+    text: (user: UserObjectType, url: string) => `To verify your account email please click on this link: ${url}`,
+  },
+};

--- a/packages/server/src/tokens.js
+++ b/packages/server/src/tokens.js
@@ -2,7 +2,7 @@
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 
-export const generateEmailToken = (length: Int = 43) => crypto.randomBytes(length).toString('hex');
+export const generateRandomToken = (length: Int = 43) => crypto.randomBytes(length).toString('hex');
 
 export const generateAccessToken = ({
   secret,

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -30,6 +30,14 @@ acorn@^4.0.4:
   version "4.0.9"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.9.tgz#2d2eb458fe3f0e31062d56cf0b1839c5dc7bd288"
 
+addressparser@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/addressparser/-/addressparser-0.3.2.tgz#59873f35e8fcf6c7361c10239261d76e15348bb2"
+
+addressparser@~0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/addressparser/-/addressparser-0.2.1.tgz#d11a5b2eeda04cfefebdf3196c10ae13db6cd607"
+
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -778,6 +786,10 @@ buffer@^4.9.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+bufferjs@=1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/bufferjs/-/bufferjs-1.1.0.tgz#095ffa39c5e6b40a2178a1169c9effc584a73201"
+
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -1050,9 +1062,26 @@ ecdsa-sig-formatter@1.0.9:
     base64url "^2.0.0"
     safe-buffer "^5.0.1"
 
+emailjs@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/emailjs/-/emailjs-1.0.8.tgz#d4240db7670dc78aff97352092d8460edc130f66"
+  dependencies:
+    addressparser "^0.3.2"
+    mimelib "0.2.14"
+    moment "= 2.11.2"
+    starttls "1.0.1"
+  optionalDependencies:
+    bufferjs "=1.1.0"
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
+
+encoding@~0.1:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
 
 enhanced-resolve@~0.9.0:
   version "0.9.1"
@@ -1394,7 +1423,7 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
-iconv-lite@0.4.13:
+iconv-lite@0.4.13, iconv-lite@~0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
@@ -2142,6 +2171,13 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.26.0"
 
+mimelib@0.2.14:
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/mimelib/-/mimelib-0.2.14.tgz#2a1aa724bd190b85bd526e6317ab6106edfd6831"
+  dependencies:
+    addressparser "~0.2.0"
+    encoding "~0.1"
+
 minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
@@ -2165,6 +2201,10 @@ minimist@1.2.0, minimist@^1.1.1, minimist@^1.2.0:
 moment@2.x.x:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.17.1.tgz#fed9506063f36b10f066c8b59a144d7faebe1d82"
+
+"moment@= 2.11.2":
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.11.2.tgz#87968e5f95ac038c2e42ac959c75819cd3f52901"
 
 ms@0.7.1:
   version "0.7.1"
@@ -2777,6 +2817,10 @@ sshpk@^1.7.0:
     jodid25519 "^1.0.0"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+starttls@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/starttls/-/starttls-1.0.1.tgz#e6081c25de6b178f5a75f8f271c1487449183b42"
 
 stream-browserify@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
#40 
Setup email part.
Add siteUrl in config to construct absolute urls for email.
Add sendVerificationEmail.
Add sendResetPasswordEmail.

To overwrite the email templates:
```javascript
AccountsServer.config({
 siteUrl: 'https://my-app.com',
 email: // a valid email config object passed to emailjs
 // https://github.com/eleith/emailjs#example-usage---text-only-emails
});

AccountsServer.emailTemplates.from = 'my-app <no-reply@my-app.com>';
AccountsServer.emailTemplates.verifyEmail.subject = (user) => `Verify your account email ${user.profile.lastname}`;
// Same for AccountsServer.emailTemplates.verifyEmail.text = (user, url)
```