### PR TITLE
feat(redux-tokens): expose js-accounts tokens to redux store

### DIFF
--- a/packages/client/src/AccountsClient.spec.js
+++ b/packages/client/src/AccountsClient.spec.js
@@ -305,6 +305,16 @@ describe('Accounts', () => {
         ...loggedInUser.user,
       }));
     });
+    it('stores tokens in redux', async () => {
+      const transport = {
+        loginWithPassword: () => Promise.resolve(loggedInUser),
+      };
+      Accounts.config({ history }, transport);
+      await Accounts.loginWithPassword('username', 'password');
+      expect(Accounts.instance.getState().get('tokens')).toEqual(Map({
+        ...loggedInUser.tokens,
+      }));
+    });
   });
   describe('logout', () => {
     it('calls callback on successful logout', async () => {
@@ -340,6 +350,35 @@ describe('Accounts', () => {
         expect(err.message).toEqual('error message');
         expect(callback.mock.calls.length).toEqual(1);
         expect(callback.mock.calls[0][0]).toEqual({ message: 'error message' });
+      }
+    });
+
+    it('clear tokens in redux', async () => {
+      const transport = {
+        logout: () => Promise.reject({ message: 'error message' }),
+      };
+      Accounts.instance.storeTokens({ tokens: { accessToken: '1' } });
+      Accounts.config({ history }, transport);
+      const callback = jest.fn();
+      try {
+        await Accounts.logout(callback);
+        throw new Error();
+      } catch (err) {
+        expect(Accounts.instance.getState().get('tokens')).toEqual(null);
+      }
+    });
+    it('clear user in redux', async () => {
+      const transport = {
+        logout: () => Promise.reject({ message: 'error message' }),
+      };
+      Accounts.instance.storeTokens({ tokens: { accessToken: '1' } });
+      Accounts.config({ history }, transport);
+      const callback = jest.fn();
+      try {
+        await Accounts.logout(callback);
+        throw new Error();
+      } catch (err) {
+        expect(Accounts.instance.getState().get('user')).toEqual(null);
       }
     });
   });

--- a/packages/client/src/module.js
+++ b/packages/client/src/module.js
@@ -3,12 +3,15 @@ import { Map } from 'immutable';
 const PATH = 'js-accounts/';
 const LOGIN = `${PATH}LOGIN`;
 const SET_USER = `${PATH}SET_USER`;
+const SET_TOKENS = `${PATH}SET_TOKENS`;
+const CLEAR_TOKENS = `${PATH}CLEAR_TOKENS`;
 const CLEAR_USER = `${PATH}CLEAR_USER`;
 const LOGGING_IN = `${PATH}LOGGING_IN`;
 
 const initialState = Map({
   isLoading: false,
   user: null,
+  tokens: null,
   loggingIn: false,
 });
 
@@ -21,6 +24,13 @@ const reducer = (state = initialState, action) => {
     case SET_USER: {
       const { user } = action.payload;
       return state.set('user', Map(user));
+    }
+    case SET_TOKENS: {
+      const { tokens } = action.payload;
+      return state.set('tokens', Map(tokens));
+    }
+    case CLEAR_TOKENS: {
+      return state.set('tokens', null);
     }
     case CLEAR_USER: {
       return state.set('user', null);
@@ -49,6 +59,17 @@ export const setUser = user => ({
   payload: {
     user,
   },
+});
+
+export const setTokens = tokens => ({
+  type: SET_TOKENS,
+  payload: {
+    tokens,
+  },
+});
+
+export const clearTokens = () => ({
+  type: CLEAR_TOKENS,
 });
 
 export const clearUser = () => ({


### PR DESCRIPTION
The goal is to have access to accessToken from Redux store, in order to know when there is available. This is also useful for accessing the token in a Redux-way.
At the moment, an app with Redux that need the accessToken needs to listen for `SET_USER` action, use async method `Accounts.tokens` and wait for the result.