### PR TITLE
feat(tokens): eager load of tokens from storage

### DIFF
--- a/packages/client/src/AccountsClient.js
+++ b/packages/client/src/AccountsClient.js
@@ -306,7 +306,9 @@ export class AccountsClient {
 const Accounts = {
   instance: AccountsClient,
   ui: {},
-  async config(options: AccountsClientConfiguration, transport: TransportInterface): Promise<AccountsClient> {
+  async config(
+    options: AccountsClientConfiguration,
+    transport: TransportInterface): Promise<AccountsClient> {
     this.instance = new AccountsClient({
       ...config,
       ...options,

--- a/packages/client/src/AccountsClient.js
+++ b/packages/client/src/AccountsClient.js
@@ -306,7 +306,7 @@ export class AccountsClient {
 const Accounts = {
   instance: AccountsClient,
   ui: {},
-  async config(options: AccountsClientConfiguration, transport: TransportInterface): Promise<any> {
+  async config(options: AccountsClientConfiguration, transport: TransportInterface): Promise<AccountsClient> {
     this.instance = new AccountsClient({
       ...config,
       ...options,


### PR DESCRIPTION
The goal is to load from the storage only once, when the app loads, and then use the inner redux store to manage the token in-memory. 
This way, we load the tokens eagerly from the storage when the `AccountsClient.config` called, and store them in-memory.
Also, the `tokens()` is always sync now, even if the storage is async (like with `AsyncStorage` of react-native)
