### PR TITLE
Make resume session with hook

### DIFF
--- a/packages/client/src/AccountsClient.js
+++ b/packages/client/src/AccountsClient.js
@@ -177,9 +177,13 @@ export class AccountsClient {
   }
 
   async resumeSession(): Promise<void> {
-    await this.refreshSession();
-    if (this.options.onResumedSessionHook && isFunction(this.options.onResumedSessionHook)) {
-      this.options.onResumedSessionHook();
+    try {
+      await this.refreshSession();
+      if (this.options.onResumedSessionHook && isFunction(this.options.onResumedSessionHook)) {
+        this.options.onResumedSessionHook();
+      }
+    } catch (err) {
+      throw (err);
     }
   }
 

--- a/packages/client/src/AccountsClient.js
+++ b/packages/client/src/AccountsClient.js
@@ -176,14 +176,11 @@ export class AccountsClient {
     this.store.dispatch(clearUser());
   }
 
-  resumeSession(): Promise<void> {
-    const session = this.refreshSession();
-    session.then(() => {
-      if (this.options.onResumedSessionHook && isFunction(this.options.onResumedSessionHook)) {
-        this.options.onResumedSessionHook();
-      }
-    });
-    return session;
+  async resumeSession(): Promise<void>  {
+    const session = await this.refreshSession();
+    if (this.options.onResumedSessionHook && isFunction(this.options.onResumedSessionHook)) {
+      this.options.onResumedSessionHook();
+    }
   }
 
   async refreshSession(): Promise<void> {

--- a/packages/client/src/AccountsClient.js
+++ b/packages/client/src/AccountsClient.js
@@ -178,7 +178,7 @@ export class AccountsClient {
 
   resumeSession(): Promise<void> {
     const session = this.refreshSession();
-  	session.then(() => {
+    session.then(() => {
       if (this.options.onResumedSessionHook && isFunction(this.options.onResumedSessionHook)) {
         this.options.onResumedSessionHook();
       }

--- a/packages/client/src/AccountsClient.js
+++ b/packages/client/src/AccountsClient.js
@@ -178,7 +178,13 @@ export class AccountsClient {
 
   resumeSession(): Promise<void> {
     // TODO Should there be any additional resume session logic here?
-    return this.refreshSession();
+    const session = this.refreshSession();
+    session.then(() => {
+      if (this.options.onResumedSessionHook && isFunction(this.options.onResumedSessionHook)) {
+        this.options.onResumedSessionHook();
+      }
+    });
+    return session;
   }
 
   async refreshSession(): Promise<void> {

--- a/packages/client/src/AccountsClient.js
+++ b/packages/client/src/AccountsClient.js
@@ -177,9 +177,8 @@ export class AccountsClient {
   }
 
   resumeSession(): Promise<void> {
-    // TODO Should there be any additional resume session logic here?
     const session = this.refreshSession();
-    session.then(() => {
+  	session.then(() => {
       if (this.options.onResumedSessionHook && isFunction(this.options.onResumedSessionHook)) {
         this.options.onResumedSessionHook();
       }

--- a/packages/client/src/AccountsClient.js
+++ b/packages/client/src/AccountsClient.js
@@ -176,8 +176,8 @@ export class AccountsClient {
     this.store.dispatch(clearUser());
   }
 
-  async resumeSession(): Promise<void>  {
-    const session = await this.refreshSession();
+  async resumeSession(): Promise<void> {
+    await this.refreshSession();
     if (this.options.onResumedSessionHook && isFunction(this.options.onResumedSessionHook)) {
       this.options.onResumedSessionHook();
     }

--- a/packages/client/src/AccountsClient.spec.js
+++ b/packages/client/src/AccountsClient.spec.js
@@ -285,6 +285,9 @@ describe('Accounts', () => {
       await Accounts.loginWithPassword('username', 'password');
       expect(onSignedInHook.mock.calls.length).toEqual(1);
     });
+    it('calls onResumeSessionHook on successful resume session', async () => {
+
+    });
     it('sets loggingIn flag to false on failed login', async () => {
       const transport = {
         loginWithPassword: () => Promise.reject('error'),

--- a/packages/client/src/AccountsClient.spec.js
+++ b/packages/client/src/AccountsClient.spec.js
@@ -117,7 +117,7 @@ describe('Accounts', () => {
         expect(message).toEqual('Username or Email is required');
       }
     });
-    it('calls callback on succesfull user creation', async () => {
+    it('calls callback on successful user creation', async () => {
       const callback = jest.fn();
       const transport = {
         createUser: () => Promise.resolve(),
@@ -166,7 +166,7 @@ describe('Accounts', () => {
       expect(Accounts.instance.loginWithPassword.mock.calls[0][0]).toEqual({ id: '123' });
       expect(Accounts.instance.loginWithPassword.mock.calls[0][1]).toEqual('123456');
     });
-    it('calls onUserCreated after succesfull user creation', async () => {
+    it('calls onUserCreated after successful user creation', async () => {
       const onUserCreated = jest.fn();
       const transport = {
         createUser: () => Promise.resolve('123'),
@@ -284,9 +284,6 @@ describe('Accounts', () => {
       Accounts.config({ history, onSignedInHook }, transport);
       await Accounts.loginWithPassword('username', 'password');
       expect(onSignedInHook.mock.calls.length).toEqual(1);
-    });
-    it('calls onResumeSessionHook on successful resume session', async () => {
-
     });
     it('sets loggingIn flag to false on failed login', async () => {
       const transport = {

--- a/packages/client/src/config.js
+++ b/packages/client/src/config.js
@@ -36,6 +36,7 @@ export type AccountsClientConfiguration = AccountsCommonConfiguration & {
   onVerifyEmailHook?: Function,
   onSignedInHook?: Function,
   onSignedOutHook?: Function,
+  onResumedSessionHook?: Function,
   onUserCreated?: (user: ?Object) => Promise<any>,
   loginOnSignUp?: boolean,
   history?: Object


### PR DESCRIPTION
Tried to create some distinction between resume session and refresh session.  The on resume session hook allows you to trigger actions via the hook that indicate first time log on.  For example, a user may wish to show a prompt to the user during initial log on.  To do so, they would attach the prompt to this on resume session hook.  signedInHook works too, but only captures initial login, not when the user uses tokens to re-authenticate. 

This has a corresponding change in rest package to change authFetch to call onRefreshSession (since this would typically be called after initial authentication)