### PR TITLE
feat(user-object-sanitizer): added user object sanitizer

### DIFF
--- a/packages/server/src/AccountsServer.js
+++ b/packages/server/src/AccountsServer.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { omit, isString, isPlainObject, isFunction, find, includes, get } from 'lodash';
+import { pick, omit, isString, isPlainObject, isFunction, find, includes, get } from 'lodash';
 import EventEmitter from 'events';
 import jwt from 'jsonwebtoken';
 import {
@@ -780,7 +780,7 @@ export class AccountsServer {
   _sanitizeUser(user: UserObjectType): UserObjectType {
     const { userObjectSanitizer } = this.options();
 
-    return userObjectSanitizer(this._internalUserSanitizer(user), omit);
+    return userObjectSanitizer(this._internalUserSanitizer(user), omit, pick);
   }
 
   _prepareMail(...args: Array<any>): any {

--- a/packages/server/src/AccountsServer.spec.js
+++ b/packages/server/src/AccountsServer.spec.js
@@ -347,6 +347,13 @@ describe('Accounts', () => {
       expect(Accounts._options.passwordAuthenticator).toBeDefined();
     });
 
+    it('set custom userObjectSanitizer', () => {
+      const testDB = {};
+      const func = () => {};
+      Accounts.config({ userObjectSanitizer: func }, testDB);
+      expect(Accounts._options.userObjectSanitizer).toBe(func);
+    });
+
     it('use default password authenticator', () => {
       const testDB = {};
       Accounts.config({}, testDB);
@@ -1386,6 +1393,24 @@ describe('Accounts', () => {
         tokens: { sessionId: '001', isImpersonated: true },
         user: impersonatedUser,
       });
+    });
+  });
+
+  describe('user sanitizer', () => {
+    const userObject = { username: 'test', services: [], id: '123' };
+
+    it('internal sanitizer should clean services field from the user object', () => {
+      Accounts.config({}, db);
+      const modifiedUser = Accounts._sanitizeUser(userObject);
+      expect(modifiedUser.services).toBeUndefined();
+    });
+
+    it('should run external sanitizier when provided one', () => {
+      Accounts.config({
+        userObjectSanitizer: (user, omit) => omit(user, ['username']),
+      }, db);
+      const modifiedUser = Accounts._sanitizeUser(userObject);
+      expect(modifiedUser.username).toBeUndefined();
     });
   });
 });

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -21,7 +21,7 @@ export type TokenConfig = {
 type EmailType = EmailTemplateType & { to: string };
 export type SendMailFunction = (emailConfig: EmailType | Object) => Promise<void>;
 export type UserObjectSanitizerFunction =
-  (userObject: UserObjectType, omitFunction: Function) => any;
+  (userObject: UserObjectType, omitFunction: Function, pickFunction: Function) => any;
 // eslint-disable-next-line max-len
 export type PrepareMailFunction = (to: string, token: string, user: UserObjectType, pathFragment: string, emailTemplate: EmailTemplateType, from: string) => Object;
 

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -20,6 +20,8 @@ export type TokenConfig = {
 
 type EmailType = EmailTemplateType & { to: string };
 export type SendMailFunction = (emailConfig: EmailType | Object) => Promise<void>;
+export type UserObjectSanitizerFunction =
+  (userObject: UserObjectType, omitFunction: Function) => any;
 // eslint-disable-next-line max-len
 export type PrepareMailFunction = (to: string, token: string, user: UserObjectType, pathFragment: string, emailTemplate: EmailTemplateType, from: string) => Object;
 
@@ -34,7 +36,8 @@ export type AccountsServerConfiguration = AccountsCommonConfiguration & {
   email?: Object,
   emailTokensExpiry?: number,
   impersonationAuthorize: (user: UserObjectType, impersonateToUser: UserObjectType) => Promise<any>,
-  validateNewUser?: (user: UserObjectType) => Promise<boolean>
+  validateNewUser?: (user: UserObjectType) => Promise<boolean>,
+  userObjectSanitizer?: UserObjectSanitizerFunction
 };
 
 export default {
@@ -48,6 +51,7 @@ export default {
       expiresIn: '1d',
     },
   },
+  userObjectSanitizer: (user: UserObjectType) => user,
   emailTokensExpiry: 1000 * 3600, // 1 hour in milis
   // TODO Investigate oauthSecretKey
   // oauthSecretKey


### PR DESCRIPTION
First, we need to sanitize the User object, right before passing it to the client or external functions to avoid exposure of `services` array with the encrypted passwords.
Also, added to `options` the ability to provide another external sanitizer, so now the developer can filter fields before sending it to the client.