### PR TITLE
feat(impersonation): added impersonation persistence optional

### DIFF
--- a/packages/client/src/AccountsClient.js
+++ b/packages/client/src/AccountsClient.js
@@ -120,9 +120,14 @@ export class AccountsClient {
     if (!res.authorized) {
       throw new AccountsError(`User unauthorized to impersonate ${username}`);
     } else {
+      const { persistImpersonation } = this.options;
       this.store.dispatch(setImpersonated(true));
       this.store.dispatch(setOriginalTokens({ accessToken, refreshToken }));
-      await this.storeTokens(res.tokens);
+
+      if (persistImpersonation) {
+        await this.storeTokens(res.tokens);
+      }
+
       this.store.dispatch(setTokens(res.tokens));
       this.store.dispatch(setUser(res.user));
       return res;

--- a/packages/client/src/AccountsClient.js
+++ b/packages/client/src/AccountsClient.js
@@ -101,8 +101,10 @@ export class AccountsClient {
 
   async loadOriginalTokensFromStorage(): Promise<void> {
     const tokens = {
-      accessToken: await this.getStorageData(getTokenKey(ORIGINAL_ACCESS_TOKEN, this.options)) || null,
-      refreshToken: await this.getStorageData(getTokenKey(ORIGINAL_REFRESH_TOKEN, this.options)) || null,
+      accessToken: await this.getStorageData(
+        getTokenKey(ORIGINAL_ACCESS_TOKEN, this.options)) || null,
+      refreshToken: await this.getStorageData(
+        getTokenKey(ORIGINAL_REFRESH_TOKEN, this.options)) || null,
     };
     this.store.dispatch(setOriginalTokens(tokens));
   }
@@ -199,12 +201,14 @@ export class AccountsClient {
     if (tokens) {
       const originalAccessToken = tokens.accessToken;
       if (originalAccessToken) {
-        await this.setStorageData(getTokenKey(ORIGINAL_ACCESS_TOKEN, this.options), originalAccessToken);
+        await this.setStorageData(
+          getTokenKey(ORIGINAL_ACCESS_TOKEN, this.options), originalAccessToken);
       }
 
       const originalRefreshToken = tokens.refreshToken;
       if (originalRefreshToken) {
-        await this.setStorageData(getTokenKey(ORIGINAL_REFRESH_TOKEN, this.options), originalRefreshToken);
+        await this.setStorageData(
+          getTokenKey(ORIGINAL_REFRESH_TOKEN, this.options), originalRefreshToken);
       }
     }
   }

--- a/packages/client/src/AccountsClient.spec.js
+++ b/packages/client/src/AccountsClient.spec.js
@@ -693,6 +693,44 @@ describe('Accounts', () => {
       });
       expect(result).toBe(impersonateResult);
     });
+
+    it('should save impersonation state and persist it in the storage', async () => {
+      const impersonatedUser = { id: 2, username: 'impUser' };
+      const impersonateResult = {
+        authorized: true,
+        tokens: { accessToken: 'newAccessToken', refreshToken: 'newRefreshToken' },
+        user: impersonatedUser,
+      };
+
+      const transport = {
+        loginWithPassword: () => Promise.resolve(loggedInUser),
+        impersonate: () => Promise.resolve(impersonateResult),
+      };
+      await Accounts.config({ history }, transport);
+      await Accounts.loginWithPassword('username', 'password');
+      Accounts.instance.storeTokens = jest.fn();
+      await Accounts.impersonate('impUser');
+      expect(Accounts.instance.storeTokens.mock.calls.length).toBe(1);
+    });
+
+    it('should not save persist impersonation when persistImpersonation=false', async () => {
+      const impersonatedUser = { id: 2, username: 'impUser' };
+      const impersonateResult = {
+        authorized: true,
+        tokens: { accessToken: 'newAccessToken', refreshToken: 'newRefreshToken' },
+        user: impersonatedUser,
+      };
+
+      const transport = {
+        loginWithPassword: () => Promise.resolve(loggedInUser),
+        impersonate: () => Promise.resolve(impersonateResult),
+      };
+      await Accounts.config({ history, persistImpersonation: false }, transport);
+      await Accounts.loginWithPassword('username', 'password');
+      Accounts.instance.storeTokens = jest.fn();
+      await Accounts.impersonate('impUser');
+      expect(Accounts.instance.storeTokens.mock.calls.length).toBe(0);
+    });
   });
 
   describe('stopImpersonation', () => {

--- a/packages/client/src/config.js
+++ b/packages/client/src/config.js
@@ -39,7 +39,8 @@ export type AccountsClientConfiguration = AccountsCommonConfiguration & {
   onResumedSessionHook?: Function,
   onUserCreated?: (user: ?Object) => Promise<any>,
   loginOnSignUp?: boolean,
-  history?: Object
+  history?: Object,
+  persistImpersonation?: boolean,
 };
 
 export default {
@@ -72,4 +73,5 @@ export default {
   onSignedInHook: () => redirect(AccountsClient.options().homePath || '/'),
   onSignedOutHook: () => redirect(AccountsClient.options().signOutPath || '/'),
   loginOnSignUp: true,
+  persistImpersonation: true,
 };

--- a/packages/client/src/config.js
+++ b/packages/client/src/config.js
@@ -40,7 +40,7 @@ export type AccountsClientConfiguration = AccountsCommonConfiguration & {
   onUserCreated?: (user: ?Object) => Promise<any>,
   loginOnSignUp?: boolean,
   history?: Object,
-  persistImpersonation?: boolean,
+  persistImpersonation?: boolean
 };
 
 export default {


### PR DESCRIPTION
When client impersonates, it's now possible to choose if to persist the impersonation state (and save it to the storage).
Configurable via `config`.

Also, fixed an issue with persisted impersonation: the original tokens need to be saved in the storage, and loaded when the client starts, in order to be able to return to the original tokens after refresh.