### PR TITLE
Impersonate check for access token without ignoring expiration

### DIFF
--- a/packages/server/src/AccountsServer.js
+++ b/packages/server/src/AccountsServer.js
@@ -314,7 +314,7 @@ export class AccountsServer {
       }
 
       try {
-        jwt.verify(accessToken, this._options.tokenSecret, { ignoreExpiration: true });
+        jwt.verify(accessToken, this._options.tokenSecret);
       } catch (err) {
         throw new AccountsError('Access token is not valid');
       }


### PR DESCRIPTION
For some reason (maybe my bad CR for the impersonation PR) we were not checking for jwt token expiration.