### PR TITLE
feat(allowed-login-fields): added ability to choose allowed login fields

### DIFF
--- a/packages/server/src/AccountsServer.js
+++ b/packages/server/src/AccountsServer.js
@@ -195,7 +195,7 @@ export class AccountsServer {
     return authFn(user, password);
   }
 
-  _validateLoginWithField(fieldName: string, user: PasswordLoginUserType): void {
+  _validateLoginWithField(fieldName: string, user: PasswordLoginUserType) {
     const allowedFields = this._options.allowedLoginFields || [];
     const isAllowed = allowedFields.includes(fieldName);
 

--- a/packages/server/src/AccountsServer.js
+++ b/packages/server/src/AccountsServer.js
@@ -195,6 +195,15 @@ export class AccountsServer {
     return authFn(user, password);
   }
 
+  _validateLoginWithField(fieldName: string, user: PasswordLoginUserType): void {
+    const allowedFields = this._options.allowedLoginFields || [];
+    const isAllowed = allowedFields.includes(fieldName);
+
+    if (!isAllowed) {
+      throw new AccountsError(`Login with ${fieldName} is not allowed!`, user);
+    }
+  }
+
   // eslint-disable-next-line max-len
   async _defaultPasswordAuthenticator(user: PasswordLoginUserType, password: PasswordType): Promise<any> {
     const { username, email, id } = isString(user)
@@ -204,10 +213,13 @@ export class AccountsServer {
     let foundUser;
 
     if (id) {
+      this._validateLoginWithField('id', user);
       foundUser = await this.db.findUserById(id);
     } else if (username) {
+      this._validateLoginWithField('username', user);
       foundUser = await this.db.findUserByUsername(username);
     } else if (email) {
+      this._validateLoginWithField('email', user);
       foundUser = await this.db.findUserByEmail(email);
     }
 

--- a/packages/server/src/AccountsServer.spec.js
+++ b/packages/server/src/AccountsServer.spec.js
@@ -362,7 +362,7 @@ describe('Accounts', () => {
 
     it('override allowedLoginFields values', () => {
       const testDB = {};
-      Accounts.config({ allowedLoginFields: ['id']}, testDB);
+      Accounts.config({ allowedLoginFields: ['id'] }, testDB);
       expect(Accounts._options.allowedLoginFields).toEqual(['id']);
     });
 

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -37,7 +37,8 @@ export type AccountsServerConfiguration = AccountsCommonConfiguration & {
   emailTokensExpiry?: number,
   impersonationAuthorize: (user: UserObjectType, impersonateToUser: UserObjectType) => Promise<any>,
   validateNewUser?: (user: UserObjectType) => Promise<boolean>,
-  userObjectSanitizer?: UserObjectSanitizerFunction
+  userObjectSanitizer?: UserObjectSanitizerFunction,
+  allowedLoginFields?: string[]
 };
 
 export default {
@@ -52,6 +53,7 @@ export default {
     },
   },
   userObjectSanitizer: (user: UserObjectType) => user,
+  allowedLoginFields: ['id', 'email', 'username'],
   emailTokensExpiry: 1000 * 3600, // 1 hour in milis
   // TODO Investigate oauthSecretKey
   // oauthSecretKey


### PR DESCRIPTION
The goal is to provide the ability for the app to choose which login fields are allowed (id, username, email), and to forbid the rest of them. 