### PR TITLE
Fix: invalid key in User object validation

### DIFF
--- a/packages/client/src/AccountsClient.js
+++ b/packages/client/src/AccountsClient.js
@@ -31,7 +31,7 @@ import { hashPassword } from './encryption';
 import type { TransportInterface } from './TransportInterface';
 import type { TokenStorage, AccountsClientConfiguration } from './config';
 
-const isValidUserObject = (user: PasswordLoginUserIdentityType) => has(user, 'user') || has(user, 'email') || has(user, 'id');
+const isValidUserObject = (user: PasswordLoginUserIdentityType) => has(user, 'username') || has(user, 'email') || has(user, 'id');
 
 const ACCESS_TOKEN = 'accounts:accessToken';
 const REFRESH_TOKEN = 'accounts:refreshToken';


### PR DESCRIPTION
`PasswordLoginUserIdentityType` has username, email and id. 
`isValidUserObject()` was looking for a `user` key instead of `username`.